### PR TITLE
Add validation in RetryAttribute

### DIFF
--- a/Interceptor.AOP.Tests/AllAttributesTests.cs
+++ b/Interceptor.AOP.Tests/AllAttributesTests.cs
@@ -51,6 +51,13 @@ namespace Interceptor.AOP.Tests
             Assert.Equal(4, callCount); // 1 original + 3 reintentos
         }
 
+        [Fact]
+        public void RetryAttribute_ShouldThrow_OnInvalidAttempts()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new RetryAttribute(0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new RetryAttribute(-1));
+        }
+
 
         [Fact]
         public async Task FallbackAttribute_ShouldExecuteFallback()

--- a/Interceptor.AOP/Attributes/RetryAttribute.cs
+++ b/Interceptor.AOP/Attributes/RetryAttribute.cs
@@ -10,6 +10,13 @@ namespace Interceptor.AOP.Attributes
     public class RetryAttribute : Attribute
     {
         public int Attempts { get; }
-        public RetryAttribute(int attempts = 3) => Attempts = attempts;
+
+        public RetryAttribute(int attempts = 3)
+        {
+            if (attempts < 1)
+                throw new ArgumentOutOfRangeException(nameof(attempts));
+
+            Attempts = attempts;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- validate attempts in `RetryAttribute` constructor
- cover negative attempts in tests

## Testing
- `dotnet test --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68484fbd97ec832fb9808bd95fcfce1a