### PR TITLE
Fix typo in documentation

### DIFF
--- a/Interceptor.AOP.AspNetCore/README.md
+++ b/Interceptor.AOP.AspNetCore/README.md
@@ -41,7 +41,7 @@ Complemento para [`Interceptor.AOP`](https://www.nuget.org/packages/Interceptor.
 ```
 ## 🧩 Configuración con DI
 
-### Ejemplo de uconfiguración en Program.cs o Startup.cs
+### Ejemplo de configuración en Program.cs o Startup.cs
 ```csharp
 services.AddInterceptedTransient<IProcesarDatosService, ProcesarDatosService>();
 ```

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Ideal para centralizar lógica transversal como **reintentos, validaciones, cach
 ```
 ## 🧩 Configuración manual (ProxyFactory)
 
-### Ejemplo de uconfiguración en Program.cs o Startup.cs
+### Ejemplo de configuración en Program.cs o Startup.cs
 ```csharp
 services.AddSingleton(provider =>
 {


### PR DESCRIPTION
## Summary
- fix typo in manual setup section of `README.md`
- fix the same typo in ASP.NET Core README

## Testing
- `dotnet test --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6848648c8360832f81e811a10bbe07d0